### PR TITLE
Used HTML <nobr> tags to prevent line breaks within example brackets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ By Tim Millard, Padgriffin, Charlie Simpson and Charlie Wilson
 
 # Programming Conventions
 
-* Always use double quotes, unless inside an HTML template variable string within an HTML tag attribute (E.g. `<a href="{% url 'default' %}"></a>`)
-* Never put commas after the last item in a list/dictionary (E.g. `["a", "b", "c"]`, not <code><del>["a", "b", "c",]</del></code>)
-* Model names are capitalised (E.g `Post`)
-* View names are capitalised, end in `View` and have words seperated by underscores (E.g. `Feed_View`)
-* Constants, settings values and field choices are uppercase and have words seperated by underscores (E.g. `STATIC_URL`)
-* Model field names are lowercase, must not contain the model name and have words seperated by underscores (E.g. `date_time_created`, not <code><del>postDateTimeCreated</del></code>)
-* HTML template names are lowercase and have words seperated by underscores (E.g. `feed.html`)
+* Always use double quotes, unless inside an HTML template variable string within an HTML tag attribute <nobr>(E.g. `<a href="{% url 'default' %}"></a>`)</nobr>
+* Never put commas after the last item in a list/dictionary <nobr>(E.g. `["a", "b", "c"]`, not <code><del>["a", "b", "c",]</del></code>)</nobr>
+* Model names are capitalised <nobr>(E.g `Post`)</nobr>
+* View names are capitalised, end in `View` and have words seperated by underscores <nobr>(E.g. `Feed_View`)</nobr>
+* Constants, settings values and field choices are uppercase and have words seperated by underscores <nobr>(E.g. `STATIC_URL`)</nobr>
+* Model field names are lowercase, must not contain the model name and have words seperated by underscores <nobr>(E.g. `date_time_created`, not <code><del>postDateTimeCreated</del></code>)</nobr>
+* HTML template names are lowercase and have words seperated by underscores <nobr>(E.g. `feed.html`)</nobr>


### PR DESCRIPTION
Prevent example brackets from being split across multiple lines in README.md